### PR TITLE
Remove Tidyverse dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,23 +23,24 @@ Imports:
     broom (>= 0.5.6),
     dplyr (>= 1.0.0),
     forecast (>= 8.0),
-    lubridate (>= 1.6.0),
     tibble (>= 1.2),
-    tidyr (>= 1.0.0),
     timetk (>= 2.1.0),
-    rlang,
-    tidyverse, 
-    tidyquant
+    rlang
 Suggests:
-    forcats,
+    ggplot2,
     knitr,
+    lubridate,
     rmarkdown,
-    testthat,
+    testthat (>= 2.0.0),
     purrr,
     readr,
     stringr,
     scales,
-    fracdiff
+    fracdiff,
+    tidyr (>= 1.0.0),
+    tidyquant,
+    zoo
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+Config/testthat/edition: 2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 # sweep (development version)
 
+* sweep no longer imports tidyverse. (@olivroy, #21)
+
+* Remove internal usage of `dplyr::select_()`. (@olivroy, #21)
+
 # sweep 0.2.5
 
-- Fixes to get `sweep` back on CRAN following inadvertent `timetk` archival. 
+* Fixes to get `sweep` back on CRAN following inadvertent `timetk` archival. 
 
 # sweep 0.2.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # sweep (development version)
 
-* sweep no longer imports tidyverse. (@olivroy, #21)
+* sweep no longer imports tidyverse. (@olivroy, #22)
 
-* Remove internal usage of `dplyr::select_()`. (@olivroy, #21)
+* Remove internal usage of `dplyr::select_()`. (@olivroy, #22)
 
 # sweep 0.2.5
 

--- a/R/sw_sweep.R
+++ b/R/sw_sweep.R
@@ -37,7 +37,6 @@
 #'
 #' @examples
 #' library(forecast)
-#' library(sweep)
 #' library(dplyr)
 #'
 #' # ETS forecasts

--- a/R/sw_tidy.R
+++ b/R/sw_tidy.R
@@ -23,7 +23,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' WWWusage %>%
 #'     auto.arima() %>%

--- a/R/sweep-package.R
+++ b/R/sweep-package.R
@@ -12,7 +12,6 @@
 #' To learn more about `sweep`, start with the vignettes:
 #'  `browseVignettes(package = "sweep")`
 #'
-#' @aliases sweep-package
 #' @keywords internal
 "_PACKAGE"
 

--- a/R/tidiers_HoltWinters.R
+++ b/R/tidiers_HoltWinters.R
@@ -19,7 +19,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' fit_hw <- USAccDeaths %>%
 #'     stats::HoltWinters()

--- a/R/tidiers_StructTS.R
+++ b/R/tidiers_StructTS.R
@@ -19,7 +19,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' fit_StructTS <- WWWusage %>%
 #'     StructTS()

--- a/R/tidiers_arima.R
+++ b/R/tidiers_arima.R
@@ -18,7 +18,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' fit_arima <- WWWusage %>%
 #'     auto.arima()

--- a/R/tidiers_bats.R
+++ b/R/tidiers_bats.R
@@ -17,7 +17,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' fit_bats <- WWWusage %>%
 #'     bats()

--- a/R/tidiers_decomposed_ts.R
+++ b/R/tidiers_decomposed_ts.R
@@ -14,7 +14,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' fit_decomposed <- USAccDeaths %>%
 #'     decompose()

--- a/R/tidiers_ets.R
+++ b/R/tidiers_ets.R
@@ -18,7 +18,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' fit_ets <- WWWusage %>%
 #'     ets()

--- a/R/tidiers_nnetar.R
+++ b/R/tidiers_nnetar.R
@@ -18,7 +18,6 @@
 #' @examples
 #' library(dplyr)
 #' library(forecast)
-#' library(sweep)
 #'
 #' fit_nnetar <- lynx %>%
 #'     nnetar()

--- a/R/utils-broom.R
+++ b/R/utils-broom.R
@@ -101,7 +101,7 @@ add_index <- function(ret, rename_index) {
 
     # Rearrange index
     ret <- ret %>%
-        dplyr::select_(rename_index, "dplyr::everything()")
+        dplyr::relocate(dplyr::all_of(rename_index))
 
     return(ret)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r, echo=FALSE}
-library(tidyverse)
 library(tidyquant)
 library(sweep)
 ```

--- a/man/sw_sweep.Rd
+++ b/man/sw_sweep.Rd
@@ -51,7 +51,6 @@ The index column name can be changed using the \code{rename_index} argument.
 }
 \examples{
 library(forecast)
-library(sweep)
 library(dplyr)
 
 # ETS forecasts

--- a/man/sw_tidy.Rd
+++ b/man/sw_tidy.Rd
@@ -32,7 +32,6 @@ ggplot2.
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 WWWusage \%>\%
     auto.arima() \%>\%

--- a/man/sweep-package.Rd
+++ b/man/sweep-package.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/sweep-package.R
 \docType{package}
 \name{sweep-package}
+\alias{sweep}
 \alias{sweep-package}
-\alias{_PACKAGE}
 \title{sweep: Tidy Tools for Forecasting}
 \description{
 The \code{sweep} package "tidies" up the modeling workflow of the \code{forecast} package.

--- a/man/tidiers_HoltWinters.Rd
+++ b/man/tidiers_HoltWinters.Rd
@@ -82,7 +82,6 @@ series.
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 fit_hw <- USAccDeaths \%>\%
     stats::HoltWinters()

--- a/man/tidiers_StructTS.Rd
+++ b/man/tidiers_StructTS.Rd
@@ -71,7 +71,6 @@ series.
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 fit_StructTS <- WWWusage \%>\%
     StructTS()

--- a/man/tidiers_arima.Rd
+++ b/man/tidiers_arima.Rd
@@ -81,7 +81,6 @@ series.
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 fit_arima <- WWWusage \%>\%
     auto.arima()

--- a/man/tidiers_bats.Rd
+++ b/man/tidiers_bats.Rd
@@ -82,7 +82,6 @@ Tidying methods for BATS and TBATS modeling of time series
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 fit_bats <- WWWusage \%>\%
     bats()

--- a/man/tidiers_decomposed_ts.Rd
+++ b/man/tidiers_decomposed_ts.Rd
@@ -35,7 +35,6 @@ Tidying methods for decomposed time series
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 fit_decomposed <- USAccDeaths \%>\%
     decompose()

--- a/man/tidiers_ets.Rd
+++ b/man/tidiers_ets.Rd
@@ -85,7 +85,6 @@ modeling of time series
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 fit_ets <- WWWusage \%>\%
     ets()

--- a/man/tidiers_nnetar.Rd
+++ b/man/tidiers_nnetar.Rd
@@ -71,7 +71,6 @@ series.
 \examples{
 library(dplyr)
 library(forecast)
-library(sweep)
 
 fit_nnetar <- lynx \%>\%
     nnetar()

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,10 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
 library(testthat)
 library(sweep)
-library(timetk)
-library(forecast)
-library(tidyverse)
-library(lubridate)
-library(tidyquant)
-library(fracdiff)
 
 test_check("sweep")

--- a/tests/testthat/test_sw_sweep.R
+++ b/tests/testthat/test_sw_sweep.R
@@ -1,40 +1,37 @@
-context("Testing sw_sweep function")
-
-
 test_that("sw_sweep test returns tibble with correct rows and columns.", {
 
     # ETS forecasts ----
     test_sweep_1 <- USAccDeaths %>%
-        ets %>%
-        forecast(level = c(80, 95, 99)) %>%
-        sw_sweep(fitted = F)
+        forecast::ets() %>%
+        forecast::forecast(level = c(80, 95, 99)) %>%
+        sw_sweep(fitted = FALSE)
 
-    expect_is(test_sweep_1, "tbl")
+    expect_s3_class(test_sweep_1, "tbl")
     expect_equal(nrow(test_sweep_1), 96)
     expect_equal(ncol(test_sweep_1), 9)
     expect_equal(colnames(test_sweep_1)[[9]], "hi.99")
 
     test_sweep_1a <- USAccDeaths %>%
-        ets %>%
-        forecast(level = c(80, 95, 99)) %>%
-        sw_sweep(fitted = T)
+        forecast::ets() %>%
+        forecast::forecast(level = c(80, 95, 99)) %>%
+        sw_sweep(fitted = TRUE)
 
     expect_equal(nrow(test_sweep_1a), 168)
 
     # Automatic ARIMA forecasts -----
     expect_equal(
         WWWusage %>%
-            auto.arima %>%
-            forecast(h=20) %>%
-            sw_sweep(fitted = F) %>%
+            forecast::auto.arima() %>%
+            forecast::forecast(h=20) %>%
+            sw_sweep(fitted = FALSE) %>%
             nrow(),
         120
     )
     expect_equal(
         WWWusage %>%
-            auto.arima %>%
-            forecast(h=20) %>%
-            sw_sweep(fitted = T) %>%
+            forecast::auto.arima() %>%
+            forecast::forecast(h=20) %>%
+            sw_sweep(fitted = TRUE) %>%
             nrow(),
         220
     )
@@ -43,86 +40,86 @@ test_that("sw_sweep test returns tibble with correct rows and columns.", {
     x <- fracdiff::fracdiff.sim(100, ma=-.4, d=.3)$series
     expect_equal(
         # Warning: no index
-        arfima(x) %>%
-            forecast(h=30) %>%
-            sw_sweep(fitted = F) %>%
+        forecast::arfima(x) %>%
+            forecast::forecast(h=30) %>%
+            sw_sweep(fitted = FALSE) %>%
             nrow(),
         130
     )
     expect_equal(
         # Warning: no index
-        arfima(x) %>%
-            forecast(h=30) %>%
-            sw_sweep(fitted = T) %>%
+        forecast::arfima(x) %>%
+            forecast::forecast(h=30) %>%
+            sw_sweep(fitted = TRUE) %>%
             nrow(),
         230
     )
 
     # STL forecasts -----
     test_sweep_2 <- USAccDeaths %>%
-        stlm(modelfunction=ar) %>%
-        forecast(h = 36) %>%
-        sw_sweep(fitted = F)
+        forecast::stlm(modelfunction=ar) %>%
+        forecast::forecast(h = 36) %>%
+        sw_sweep(fitted = FALSE)
 
-    expect_is(test_sweep_2, "tbl")
+    expect_s3_class(test_sweep_2, "tbl")
     expect_equal(nrow(test_sweep_2), 108)
     expect_equal(ncol(test_sweep_2), 7)
     expect_equal(colnames(test_sweep_2)[[7]], "hi.95")
 
     test_sweep_2a <- USAccDeaths %>%
-        stlm(modelfunction=ar) %>%
-        forecast(h=36) %>%
+        forecast::stlm(modelfunction=ar) %>%
+        forecast::forecast(h=36) %>%
         sw_sweep(fitted = T)
     expect_equal(nrow(test_sweep_2a), 180)
 
     # STLF -----
     test_sweep_3 <- AirPassengers %>%
-        stlf(lambda=0) %>%
+        forecast::stlf(lambda=0) %>%
         sw_sweep(fitted = F)
 
-    expect_is(test_sweep_3, "tbl")
+    expect_s3_class(test_sweep_3, "tbl")
     expect_equal(nrow(test_sweep_3), 168)
     expect_equal(ncol(test_sweep_3), 7)
     expect_equal(colnames(test_sweep_3)[[7]], "hi.95")
 
     test_sweep_3a <- AirPassengers %>%
-        stlf(lambda=0) %>%
-        sw_sweep(fitted = T)
+        forecast::stlf(lambda=0) %>%
+        sw_sweep(fitted = TRUE)
     expect_equal(nrow(test_sweep_3a), 312)
 
 
     # STL -----
     test_sweep_4 <- USAccDeaths %>%
-        stl(s.window='periodic') %>%
-        forecast %>%
-        sw_sweep(fitted = F)
+        stats::stl(s.window='periodic') %>%
+        forecast::forecast() %>%
+        sw_sweep(fitted = FALSE)
 
-    expect_is(test_sweep_4, "tbl")
+    expect_s3_class(test_sweep_4, "tbl")
     expect_equal(nrow(test_sweep_4), 96)
     expect_equal(ncol(test_sweep_4), 7)
     expect_equal(colnames(test_sweep_4)[[7]], "hi.95")
 
     test_sweep_4a <- USAccDeaths %>%
-        stl(s.window='periodic') %>%
-        forecast %>%
-        sw_sweep(fitted = T)
+        stats::stl(s.window='periodic') %>%
+        forecast::forecast() %>%
+        sw_sweep(fitted = TRUE)
     expect_equal(nrow(test_sweep_4a), 168)
 
     # TBATS forecast -----
     test_sweep_5 <- USAccDeaths %>%
-        tbats %>%
-        forecast(level = c(80, 95)) %>%
+        forecast::tbats() %>%
+        forecast::forecast(level = c(80, 95)) %>%
         sw_sweep(fitted = F)
 
-    expect_is(test_sweep_5, "tbl")
+    expect_s3_class(test_sweep_5, "tbl")
     expect_equal(nrow(test_sweep_5), 96)
     expect_equal(ncol(test_sweep_5), 7)
     expect_equal(colnames(test_sweep_5)[[7]], "hi.95")
 
     test_sweep_5a <- USAccDeaths %>%
-        tbats %>%
-        forecast(level = c(80, 95)) %>%
-        sw_sweep(fitted = T)
+        forecast::tbats() %>%
+        forecast::forecast(level = c(80, 95)) %>%
+        sw_sweep(fitted = TRUE)
     expect_equal(nrow(test_sweep_5a), 168)
 
     # sweep.default() -----
@@ -133,34 +130,34 @@ test_that("sw_sweep test returns tibble with correct rows and columns.", {
     # Check warning if no timetk index exists
     expect_warning(
         WWWusage %>%
-            auto.arima() %>%
-            forecast() %>%
-            sw_sweep(timetk_idx = T)
+            forecast::auto.arima() %>%
+            forecast::forecast() %>%
+            sw_sweep(timetk_idx = TRUE)
     )
 
     # Check integration with tk_make_future_timeseries()
     monthly_bike_sales <- bike_sales %>%
-        mutate(month.date = as_date(as.yearmon(order.date))) %>%
-        group_by(month.date) %>%
-        summarize(total.daily.sales = sum(price.ext))
+        dplyr::mutate(month.date = lubridate::as_date(zoo::as.yearmon(order.date))) %>%
+        dplyr::group_by(month.date) %>%
+        dplyr::summarize(total.daily.sales = sum(price.ext))
 
     monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, freq = 12, silent = TRUE)
 
-    fit <- auto.arima(monthly_bike_sales_ts)
+    fit <- forecast::auto.arima(monthly_bike_sales_ts)
 
-    fcast <- forecast(fit)
+    fcast <- forecast::forecast(fit)
 
     test <- sw_sweep(fcast)
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon", exact = TRUE)
 
-    test <- sw_sweep(fcast, timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- sw_sweep(fcast, timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date", exact = TRUE)
 
-    test <- sw_sweep(fcast, timetk_idx = T, skip_values = ymd("2017-12-01")) %>% tail()
-    expect_equal(test$index[[6]], ymd("2018-01-01"))
+    test <- sw_sweep(fcast, timetk_idx = T, skip_values = lubridate::ymd("2017-12-01")) %>% tail()
+    expect_equal(test$index[[6]], lubridate::ymd("2018-01-01"))
 
-    test <- sw_sweep(fcast, fitted = T, timetk_idx = T, skip_values = ymd("2017-12-01"))
-    expect_equal(test$index[[nrow(test)]], ymd("2018-01-01"))
+    test <- sw_sweep(fcast, fitted = TRUE, timetk_idx = T, skip_values = lubridate::ymd("2017-12-01"))
+    expect_equal(test$index[[nrow(test)]], lubridate::ymd("2018-01-01"))
 })
 
 

--- a/tests/testthat/test_tidiers_StructTS.R
+++ b/tests/testthat/test_tidiers_StructTS.R
@@ -1,23 +1,20 @@
-context("Testing StructTS tidiers")
-
-
 # FUNCTION: sw_*.StructTS -----
 test_that("sw_*.StructTS test returns tibble with correct rows and columns.", {
 
     # StructTS()  ----
     fit_StructTS <- WWWusage %>%
-        StructTS()
+        stats::StructTS()
 
     # sw_tidy ----
     test <- sw_tidy(fit_StructTS)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 3)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- sw_glance(fit_StructTS)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 12)
@@ -25,7 +22,7 @@ test_that("sw_*.StructTS test returns tibble with correct rows and columns.", {
     # sw_augment ----
     # Test normal
     test <- sw_augment(fit_StructTS, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 100)
     expect_equal(ncol(test), 4)
@@ -35,24 +32,24 @@ test_that("sw_*.StructTS test returns tibble with correct rows and columns.", {
     # Check warning if no timetk index exists
     expect_warning(
         USAccDeaths %>%
-            StructTS() %>%
-            sw_augment(timetk_idx = T)
+            stats::StructTS() %>%
+            sw_augment(timetk_idx = TRUE)
     )
 
     # Check integration with tk_make_future_timeseries()
     monthly_bike_sales <- bike_sales %>%
-        mutate(month.date = as_date(as.yearmon(order.date))) %>%
-        group_by(month.date) %>%
-        summarize(total.daily.sales = sum(price.ext))
+        dplyr::mutate(month.date = lubridate::as_date(zoo::as.yearmon(order.date))) %>%
+        dplyr::group_by(month.date) %>%
+        dplyr::summarize(total.daily.sales = sum(price.ext))
 
-    monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, freq = 12, silent = TRUE)
+    monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, frequency = 12, silent = TRUE)
 
-    fit <- StructTS(monthly_bike_sales_ts)
+    fit <- stats::StructTS(monthly_bike_sales_ts)
 
     test <- fit %>% sw_augment()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
-    test <- fit %>% sw_augment(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- fit %>% sw_augment(timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date")
 
 })

--- a/tests/testthat/test_tidiers_arima.R
+++ b/tests/testthat/test_tidiers_arima.R
@@ -1,6 +1,3 @@
-context("Testing arima tidiers")
-
-
 # FUNCTION: sw_*.Arima -----
 test_that("sw_*.Arima test returns tibble with correct rows and columns.", {
 
@@ -10,21 +7,21 @@ test_that("sw_*.Arima test returns tibble with correct rows and columns.", {
 
     # sw_tidy ----
     test <- sw_tidy(fit_arima)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 2)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- sw_glance(fit_arima)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 12)
 
     # sw_augment ----
     test <- sw_augment(fit_arima, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 100)
     expect_equal(ncol(test), 4)
@@ -36,14 +33,14 @@ test_that("sw_*.Arima test returns tibble with correct rows and columns.", {
 
     # sw_tidy ----
     test <- sw_tidy(fit_arima_stats)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 2)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- suppressWarnings(sw_glance(fit_arima_stats))
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 10)
@@ -51,7 +48,7 @@ test_that("sw_*.Arima test returns tibble with correct rows and columns.", {
 
     # sw_augment ----
     test <- suppressWarnings(sw_augment(fit_arima_stats, rename_index = "date"))
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 100)
     expect_equal(ncol(test), 2) # stats::arima() returns only one column for residuals
@@ -65,44 +62,44 @@ test_that("sw_*.Arima test returns tibble with correct rows and columns.", {
     # Check warning if no timetk index exists
     expect_warning(
         WWWusage %>%
-            auto.arima() %>%
-            sw_augment(timetk_idx = T)
+            forecast::auto.arima() %>%
+            sw_augment(timetk_idx = TRUE)
     )
 
     # Test sw_augment
     monthly_bike_sales <- bike_sales %>%
-        mutate(month.date = as_date(as.yearmon(order.date))) %>%
-        group_by(month.date) %>%
-        summarize(total.daily.sales = sum(price.ext))
+        dplyr::mutate(month.date = lubridate::as_date(zoo::as.yearmon(order.date))) %>%
+        dplyr::group_by(month.date) %>%
+        dplyr::summarize(total.daily.sales = sum(price.ext))
 
     monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, freq = 12, silent = TRUE)
 
-    fit <- auto.arima(monthly_bike_sales_ts)
+    fit <- forecast::auto.arima(monthly_bike_sales_ts)
 
     test <- fit %>% sw_augment()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
-    test <- fit %>% sw_augment(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- fit %>% sw_augment(timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date")
 
     # agument data = ts
 
     test <- fit %>% sw_augment(data = monthly_bike_sales_ts, timetk_idx = F)
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
     expect_equal(colnames(test)[[2]], "total.daily.sales")
 
     test <- fit %>% sw_augment(data = monthly_bike_sales_ts, timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    expect_s3_class(test$index, "Date")
 
-    test <- fit %>% sw_augment(data = monthly_bike_sales_ts, timetk_idx = T, rename_index = "date")
-    expect_equal(class(test$date), "Date")
+    test <- fit %>% sw_augment(data = monthly_bike_sales_ts, timetk_idx = TRUE, rename_index = "date")
+    expect_s3_class(test$date, "Date")
 
     # augment data = tbl
 
-    test <- fit %>% sw_augment(data = monthly_bike_sales, timetk_idx = F)
-    expect_equal(class(test$month.date), "Date")
+    test <- fit %>% sw_augment(data = monthly_bike_sales, timetk_idx = FALSE)
+    expect_s3_class(test$month.date, "Date")
     expect_equal(colnames(test)[[2]], "total.daily.sales")
 
-    expect_warning(fit %>% sw_augment(data = monthly_bike_sales, timetk_idx = T))
+    expect_warning(fit %>% sw_augment(data = monthly_bike_sales, timetk_idx = TRUE))
 
 })

--- a/tests/testthat/test_tidiers_bats_tbats.R
+++ b/tests/testthat/test_tidiers_bats_tbats.R
@@ -1,6 +1,3 @@
-context("Testing bats and tbats tidiers")
-
-
 # FUNCTION: sw_*.bats -----
 test_that("sw_*.bats test returns tibble with correct rows and columns.", {
 
@@ -10,26 +7,26 @@ test_that("sw_*.bats test returns tibble with correct rows and columns.", {
 
     # sw_tidy ----
     test <- sw_tidy(fit_bats)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 7)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- sw_glance(fit_bats)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 12)
 
     # sw_augment ----
     test <- sw_augment(fit_bats, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 100)
     expect_equal(ncol(test), 4)
     expect_equal(colnames(test)[[1]], "date")
 
     # sw_tidy_decomp ----
     test <- sw_tidy_decomp(fit_bats)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 100)
     expect_equal(ncol(test), 3)
 
@@ -40,26 +37,26 @@ test_that("sw_*.bats test returns tibble with correct rows and columns.", {
 
     # sw_tidy ----
     test <- sw_tidy(fit_tbats)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 8)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- sw_glance(fit_tbats)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 12)
 
     # sw_augment ----
     test <- sw_augment(fit_tbats, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 4)
     expect_equal(colnames(test)[[1]], "date")
 
     # sw_tidy_decomp ----
     test <- sw_tidy_decomp(fit_tbats)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 5)
 
@@ -68,56 +65,56 @@ test_that("sw_*.bats test returns tibble with correct rows and columns.", {
     # Check warning if no timetk index exists
     expect_warning(
         WWWusage %>%
-            bats() %>%
-            sw_augment(timetk_idx = T)
+            forecast::bats() %>%
+            sw_augment(timetk_idx = TRUE)
     )
 
     monthly_bike_sales <- bike_sales %>%
-        mutate(month.date = as_date(as.yearmon(order.date))) %>%
-        group_by(month.date) %>%
-        summarize(total.daily.sales = sum(price.ext))
+        dplyr::mutate(month.date = lubridate::as_date(zoo::as.yearmon(order.date))) %>%
+        dplyr::group_by(month.date) %>%
+        dplyr::summarize(total.daily.sales = sum(price.ext))
 
-    monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, freq = 12, silent = TRUE)
+    monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, frequency = 12, silent = TRUE)
 
     # BATS timetk index ----
 
-    fit <- bats(monthly_bike_sales_ts)
+    fit <- forecast::bats(monthly_bike_sales_ts)
 
     # timetk_idx sw_augment ----
     test <- fit %>% sw_augment()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
-    test <- fit %>% sw_augment(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- fit %>% sw_augment(timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date")
 
     # timetk_idx sw_tidy_decomp -----
     test <- fit %>% sw_tidy_decomp()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
     test <- fit %>% sw_tidy_decomp(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    expect_s3_class(test$index, "Date")
 
     # TBATS timetk index ----
 
     data_ts <- USAccDeaths %>%
         tk_tbl() %>%
-        mutate(index = as_date(index)) %>%
-        tk_ts(start = 1973, freq = 12, silent = TRUE)
+        dplyr::mutate(index = lubridate::as_date(index)) %>%
+        tk_ts(start = 1973, frequency = 12, silent = TRUE)
 
-    fit <- tbats(data_ts)
+    fit <- forecast::tbats(data_ts)
 
     # timetk_idx sw_augment ----
     test <- fit %>% sw_augment()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
-    test <- fit %>% sw_augment(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- fit %>% sw_augment(timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date")
 
     # timetk_idx sw_tidy_decomp -----
     test <- fit %>% sw_tidy_decomp()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
-    test <- fit %>% sw_tidy_decomp(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- fit %>% sw_tidy_decomp(timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date")
 
 })

--- a/tests/testthat/test_tidiers_decomposed_ts.R
+++ b/tests/testthat/test_tidiers_decomposed_ts.R
@@ -1,6 +1,3 @@
-context("Testing decomposed.ts tidiers")
-
-
 # FUNCTION sw_*.decomposed.ts ----
 test_that("sw_*.decomposed.ts test returns tibble with correct rows and columns.", {
 
@@ -10,7 +7,7 @@ test_that("sw_*.decomposed.ts test returns tibble with correct rows and columns.
 
     # sw_tidy_decomp ----
     test <- sw_tidy_decomp(fit_decomposed_ts)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 6)
 
@@ -18,16 +15,16 @@ test_that("sw_*.decomposed.ts test returns tibble with correct rows and columns.
 
     data_ts <- USAccDeaths %>%
         tk_tbl() %>%
-        mutate(index = as_date(index)) %>%
-        tk_ts(start = 1973, freq = 12, silent = TRUE)
+        dplyr::mutate(index = lubridate::as_date(index)) %>%
+        tk_ts(start = 1973, frequency = 12, silent = TRUE)
 
     fit <- decompose(data_ts)
 
     # timetk_idx sw_tidy_decomp -----
     test <- fit %>% sw_tidy_decomp()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
     test <- fit %>% sw_tidy_decomp(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    expect_s3_class(test$index, "Date")
 
 })

--- a/tests/testthat/test_tidiers_ets.R
+++ b/tests/testthat/test_tidiers_ets.R
@@ -1,6 +1,3 @@
-context("Testing ets tidiers")
-
-
 # FUNCTION: sw_*.ets -----
 test_that("sw_*.ets test returns tibble with correct rows and columns.", {
 
@@ -10,28 +7,28 @@ test_that("sw_*.ets test returns tibble with correct rows and columns.", {
 
     # sw_tidy ----
     test <- sw_tidy(fit_ets)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 5)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- sw_glance(fit_ets)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 12)
 
     # sw_augment ----
     test <- sw_augment(fit_ets, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 100)
     expect_equal(ncol(test), 4)
     expect_equal(colnames(test)[[1]], "date")
 
     # sw_tidy_decomp ----
     test <- sw_tidy_decomp(fit_ets)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 101)
     expect_equal(ncol(test), 4)
 
@@ -40,31 +37,31 @@ test_that("sw_*.ets test returns tibble with correct rows and columns.", {
     # Check warning if no timetk index exists
     expect_warning(
         USAccDeaths %>%
-            ets() %>%
-            sw_augment(timetk_idx = T)
+            forecast::ets() %>%
+            sw_augment(timetk_idx = TRUE)
     )
 
     # Check integration with tk_make_future_timeseries()
     monthly_bike_sales <- bike_sales %>%
-        mutate(month.date = as_date(as.yearmon(order.date))) %>%
-        group_by(month.date) %>%
-        summarize(total.daily.sales = sum(price.ext))
+        dplyr::mutate(month.date = lubridate::as_date(zoo::as.yearmon(order.date))) %>%
+        dplyr::group_by(month.date) %>%
+        dplyr::summarize(total.daily.sales = sum(price.ext))
 
-    monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, freq = 12, silent = TRUE)
+    monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, frequency = 12, silent = TRUE)
 
-    fit <- ets(monthly_bike_sales_ts)
+    fit <- forecast::ets(monthly_bike_sales_ts)
 
     # sw_augment ----
     test <- fit %>% sw_augment()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
     test <- fit %>% sw_augment(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    expect_s3_class(test$index, "Date")
 
     # sw_tidy_decomp -----
     test <- fit %>% sw_tidy_decomp()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
     test <- fit %>% sw_tidy_decomp(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    expect_s3_class(test$index, "Date")
 })

--- a/tests/testthat/test_tidiers_hw.R
+++ b/tests/testthat/test_tidiers_hw.R
@@ -1,5 +1,3 @@
-context("Testing HoltWinters tidiers")
-
 # FUNCTION: sw_*.HoltWinters -----
 test_that("sw_*.HoltWinters test returns tibble with correct rows and columns.", {
 
@@ -9,38 +7,38 @@ test_that("sw_*.HoltWinters test returns tibble with correct rows and columns.",
 
     # sw_tidy ----
     test <- sw_tidy(fit_hw)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 17)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- sw_glance(fit_hw)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 12)
 
     # sw_augment ----
     # Test normal
     test <- sw_augment(fit_hw, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 4)
 
     # Test passing data
     test <- sw_augment(fit_hw, data = USAccDeaths, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 4)
 
     # Test passing incorrect data
     expect_warning(sw_augment(fit_hw,
-                              data = timetk::tk_ts(USAccDeaths[1:50], freq = 12, start = 1973),
+                              data = timetk::tk_ts(USAccDeaths[1:50], frequency = 12, start = 1973),
                               rename_index = "date")
     )
 
     # sw_tidy_decomp ----
     test <- sw_tidy_decomp(fit_hw)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 6)
 
@@ -50,32 +48,32 @@ test_that("sw_*.HoltWinters test returns tibble with correct rows and columns.",
     # Check warning if no timetk index exists
     expect_warning(
         USAccDeaths %>%
-            HoltWinters() %>%
-            sw_augment(timetk_idx = T)
+            stats::HoltWinters() %>%
+            sw_augment(timetk_idx = TRUE)
     )
 
     # Check integration with tk_make_future_timeseries()
     monthly_bike_sales <- bike_sales %>%
-        mutate(month.date = as_date(as.yearmon(order.date))) %>%
-        group_by(month.date) %>%
-        summarize(total.daily.sales = sum(price.ext))
+        dplyr::mutate(month.date = lubridate::as_date(zoo::as.yearmon(order.date))) %>%
+        dplyr::group_by(month.date) %>%
+        dplyr::summarize(total.daily.sales = sum(price.ext))
 
     monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, freq = 12, silent = TRUE)
 
-    fit <- HoltWinters(monthly_bike_sales_ts)
+    fit <- stats::HoltWinters(monthly_bike_sales_ts)
 
     # timetk_idx sw_augment ----
     test <- fit %>% sw_augment()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
-    test <- fit %>% sw_augment(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- fit %>% sw_augment(timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date")
 
     # timetk_idx sw_tidy_decomp -----
     test <- fit %>% sw_tidy_decomp()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon")
 
-    test <- fit %>% sw_tidy_decomp(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    test <- fit %>% sw_tidy_decomp(timetk_idx = TRUE)
+    expect_s3_class(test$index, "Date")
 
 })

--- a/tests/testthat/test_tidiers_lm.R
+++ b/tests/testthat/test_tidiers_lm.R
@@ -1,6 +1,3 @@
-context("Testing lm tidiers")
-
-
 # FUNCTION: sw_*.default -----
 test_that("sw_*.default test returns tibble with correct rows and columns.", {
 
@@ -9,14 +6,14 @@ test_that("sw_*.default test returns tibble with correct rows and columns.", {
 
     # sw_tidy ----
     test <- sw_tidy(fit_lm)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 2)
     expect_equal(ncol(test), 5)
 
     # sw_glance ----
     test <- sw_glance(fit_lm)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 1)
     # expect_equal(ncol(test), 12)
@@ -26,7 +23,7 @@ test_that("sw_*.default test returns tibble with correct rows and columns.", {
         suppressWarnings(
             sw_augment(fit_lm)
         )
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 32)
     # expect_equal(ncol(test), 8)

--- a/tests/testthat/test_tidiers_nnetar.R
+++ b/tests/testthat/test_tidiers_nnetar.R
@@ -1,4 +1,4 @@
-context("Testing nnetar tidiers")
+# Testing nnetar tidiers
 
 
 # FUNCTION: sw_*.nnetar -----
@@ -6,18 +6,18 @@ test_that("sw_*.nnetar test returns tibble with correct rows and columns.", {
 
     # nnetar()  ----
     fit_nnetar <- USAccDeaths %>%
-        nnetar()
+        forecast::nnetar()
 
     # sw_tidy ----
     test <- sw_tidy(fit_nnetar)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 4)
     expect_equal(ncol(test), 2)
 
     # sw_glance ----
     test <- sw_glance(fit_nnetar)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 1)
     expect_equal(ncol(test), 12)
@@ -25,14 +25,14 @@ test_that("sw_*.nnetar test returns tibble with correct rows and columns.", {
     # sw_augment ----
     # Test normal
     test <- sw_augment(fit_nnetar, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 4)
 
     # Test passing data
     test <- sw_augment(fit_nnetar, data = USAccDeaths, rename_index = "date")
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     # expect_false(any(lapply(test, is.factor) %>% unlist())) # No factors
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 4)
@@ -48,24 +48,24 @@ test_that("sw_*.nnetar test returns tibble with correct rows and columns.", {
     # Check warning if no timetk index exists
     expect_warning(
         WWWusage %>%
-            nnetar() %>%
-            sw_augment(timetk_idx = T)
+            forecast::nnetar() %>%
+            sw_augment(timetk_idx = TRUE)
     )
 
     # Check integration with tk_make_future_timeseries()
     monthly_bike_sales <- bike_sales %>%
-        mutate(month.date = as_date(as.yearmon(order.date))) %>%
-        group_by(month.date) %>%
-        summarize(total.daily.sales = sum(price.ext))
+        dplyr::mutate(month.date = lubridate::as_date(zoo::as.yearmon(order.date))) %>%
+        dplyr::group_by(month.date) %>%
+        dplyr::summarize(total.daily.sales = sum(price.ext))
 
     monthly_bike_sales_ts <- tk_ts(monthly_bike_sales, start = 2011, freq = 12, silent = TRUE)
 
-    fit <- nnetar(monthly_bike_sales_ts)
+    fit <- forecast::nnetar(monthly_bike_sales_ts)
 
     test <- fit %>% sw_augment()
-    expect_equal(class(test$index), "yearmon")
+    expect_s3_class(test$index, "yearmon", exact = TRUE)
 
     test <- fit %>% sw_augment(timetk_idx = T)
-    expect_equal(class(test$index), "Date")
+    expect_s3_class(test$index, "Date", exact = TRUE)
 
 })

--- a/tests/testthat/test_tidiers_stl.R
+++ b/tests/testthat/test_tidiers_stl.R
@@ -1,6 +1,3 @@
-context("Testing STL tidiers")
-
-
 # FUNCTION sw_*.stl -----
 test_that("sw_*.stl test returns tibble with correct rows and columns.", {
 
@@ -10,17 +7,17 @@ test_that("sw_*.stl test returns tibble with correct rows and columns.", {
 
     # sw_tidy_decomp ----
     test <- sw_tidy_decomp(fit_stl)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 6)
 
     # stlm() ----
     fit_stlm <- USAccDeaths %>%
-        stlm(modelfunction=ar)
+        forecast::stlm(modelfunction=ar)
 
     # sw_tidy_decomp ----
     test <- sw_tidy_decomp(fit_stlm)
-    expect_is(test, "tbl")
+    expect_s3_class(test, "tbl")
     expect_equal(nrow(test), 72)
     expect_equal(ncol(test), 6)
 
@@ -29,16 +26,16 @@ test_that("sw_*.stl test returns tibble with correct rows and columns.", {
 
     # data_ts <- USAccDeaths %>%
     #     tk_tbl() %>%
-    #     mutate(index = as_date(index)) %>%
+    #     dplyr::mutate(index = lubridateLLas_date(index)) %>%
     #     tk_ts(start = 1973, freq = 12, silent = TRUE)
     #
     # fit <- stl(data_ts, s.window = "periodic")
     #
     # # timetk_idx sw_tidy_decomp -----
     # test <- fit %>% sw_tidy_decomp()
-    # expect_equal(class(test$index), "yearmon")
+    # expect_s3_class(test$index, "yearmon")
 
     # timekix_idx not supported with stats::stl()
-    # test <- fit %>% sw_tidy_decomp(timetk_idx = T)
-    # expect_equal(class(test$index), "Date")
+    # test <- fit %>% sw_tidy_decomp(timetk_idx = TRUE)
+    # expect_s3_class(test$index, "Date")
 })

--- a/vignettes/SW00_Introduction_to_sweep.Rmd
+++ b/vignettes/SW00_Introduction_to_sweep.Rmd
@@ -41,7 +41,7 @@ To illustrate, let's take a basic forecasting workflow starting from data collec
 Before we get started, load the following packages.
 
 ```{r, message = F}
-library(tidyverse)
+library(ggplot2)
 library(tidyquant)
 library(timetk)
 library(sweep)
@@ -65,7 +65,7 @@ We can quickly visualize using the `ggplot2` package. We can see that there appe
 ```{r}
 alcohol_sales_tbl %>%
     ggplot(aes(x = date, y = price)) +
-    geom_line(size = 1, color = palette_light()[[1]]) +
+    geom_line(linewidth = 1, color = palette_light()[[1]]) +
     geom_smooth(method = "loess") +
     labs(title = "US Alcohol Sales: Monthly", x = "", y = "Millions") +
     scale_y_continuous(labels = scales::dollar) +
@@ -202,8 +202,8 @@ We can review the decomposition using `ggplot2` as well.  The data will need to 
 
 ```{r}
 decomp_fit_ets %>%
-    gather(key = key, value = value, -index) %>%
-    mutate(key = forcats::as_factor(key)) %>%
+    tidyr::gather(key = key, value = value, -index) %>%
+    dplyr::mutate(key = as.factor(key)) %>%
     ggplot(aes(x = index, y = value, group = key)) +
     geom_line(color = palette_light()[[2]]) +
     geom_ma(ma_fun = SMA, n = 12, size = 1) +
@@ -248,13 +248,13 @@ Let's visualize the forecast with `ggplot2`. We'll use a combination of `geom_li
 sw_sweep(fcast_ets) %>%
     ggplot(aes(x = index, y = price, color = key)) +
     geom_ribbon(aes(ymin = lo.95, ymax = hi.95), 
-                fill = "#D5DBFF", color = NA, size = 0) +
+                fill = "#D5DBFF", color = NA, linewidth = 0) +
     geom_ribbon(aes(ymin = lo.80, ymax = hi.80, fill = key), 
-                fill = "#596DD5", color = NA, size = 0, alpha = 0.8) +
-    geom_line(size = 1) +
+                fill = "#596DD5", color = NA, linewidth = 0, alpha = 0.8) +
+    geom_line(linewidth = 1) +
     labs(title = "US Alcohol Sales, ETS Model Forecast", x = "", y = "Millions",
          subtitle = "Regular Time Index") +
-    scale_y_continuous(labels = scales::dollar) +
+    scale_y_continuous(labels = scales::label_dollar()) +
     scale_x_yearmon(n = 12, format = "%Y") +
     scale_color_tq() +
     scale_fill_tq() +
@@ -279,10 +279,10 @@ We can build the same plot with dates in the x-axis now.
 sw_sweep(fcast_ets, timetk_idx = TRUE) %>%
     ggplot(aes(x = index, y = price, color = key)) +
     geom_ribbon(aes(ymin = lo.95, ymax = hi.95), 
-                fill = "#D5DBFF", color = NA, size = 0) +
+                fill = "#D5DBFF", color = NA, linewidth = 0) +
     geom_ribbon(aes(ymin = lo.80, ymax = hi.80, fill = key), 
-                fill = "#596DD5", color = NA, size = 0, alpha = 0.8) +
-    geom_line(size = 1) +
+                fill = "#596DD5", color = NA, linewidth = 0, alpha = 0.8) +
+    geom_line(linewidth = 1) +
     labs(title = "US Alcohol Sales, ETS Model Forecast", x = "", y = "Millions", 
          subtitle = "Irregular Time Index") +
     scale_y_continuous(labels = scales::dollar) +

--- a/vignettes/SW01_Forecasting_Time_Series_Groups.Rmd
+++ b/vignettes/SW01_Forecasting_Time_Series_Groups.Rmd
@@ -40,7 +40,11 @@ In this vignette we'll review how `sweep` can help the __first situation__: _App
 Before we get started, load the following packages.
 
 ```{r, message = F}
-library(tidyverse)
+library(dplyr)
+library(ggplot2)
+library(tidyr)
+library(purrr)
+library(lubridate)
 library(tidyquant)
 library(timetk)
 library(sweep)
@@ -231,9 +235,9 @@ Visualization is just one final step.
 monthly_qty_by_cat2_fcast_tidy %>%
     ggplot(aes(x = index, y = total.qty, color = key, group = category.secondary)) +
     geom_ribbon(aes(ymin = lo.95, ymax = hi.95), 
-                fill = "#D5DBFF", color = NA, size = 0) +
+                fill = "#D5DBFF", color = NA, linewidth = 0) +
     geom_ribbon(aes(ymin = lo.80, ymax = hi.80, fill = key), 
-                fill = "#596DD5", color = NA, size = 0, alpha = 0.8) +
+                fill = "#596DD5", color = NA, linewidth = 0, alpha = 0.8) +
     geom_line() +
     labs(title = "Bike Quantity Sold By Secondary Category",
          subtitle = "ETS Model Forecasts",

--- a/vignettes/SW02_Forecasting_Multiple_Models.Rmd
+++ b/vignettes/SW02_Forecasting_Multiple_Models.Rmd
@@ -40,7 +40,11 @@ In this vignette we'll review how `sweep` can help the __second situation__: _Ap
 Before we get started, load the following packages.
 
 ```{r, message = F}
-library(tidyverse)
+library(tidyr)
+library(dplyr)
+library(purrr)
+library(lubridate)
+library(ggplot2)
 library(tidyquant)
 library(timetk)
 library(sweep)
@@ -98,9 +102,9 @@ Another quick visualization to show the reduction in granularity.
 ```{r}
 gas_prices_quarterly %>%
     ggplot(aes(x = date, y = price)) +
-    geom_line(color = palette_light()[[1]], size = 1) +
+    geom_line(color = palette_light()[[1]], linewidth = 1) +
     labs(title = "Gasoline Prices, Quarterly", x = "", y = "USD") +
-    scale_y_continuous(labels = scales::dollar) +
+    scale_y_continuous(labels = scales::label_dollar()) +
     scale_x_date(date_breaks = "5 years", date_labels = "%Y") +
     theme_tq()
 ```
@@ -140,6 +144,7 @@ df$params
 Next we apply the functions to the parameters using a special function, `invoke_map()`. The parameter lists in the "params" column are passed to the function in the "f" column. The output is in a nested list-column named "out".
 
 ```{r}
+# FIXME invoke_map is deprecated
 df_out <- df %>% 
     mutate(out = invoke_map(f, params))
 df_out
@@ -188,10 +193,10 @@ models_list <- list(
 )
 ```
 
-Now, convert to a data frame using the function, `enframe()` that turns lists into tibbles. Set the arguments `name = "f"` and `value = "params"`. In doing so we get a bonus: the model names are the now convieniently located in column "f".
+Now, convert to a data frame using the function, `enframe()` that turns lists into tibbles. Set the arguments `name = "f"` and `value = "params"`. In doing so we get a bonus: the model names are the now conveniently located in column "f".
 
 ```{r}
-models_tbl <- enframe(models_list, name = "f", value = "params")
+models_tbl <- tibble::enframe(models_list, name = "f", value = "params")
 models_tbl
 ```
 
@@ -199,7 +204,7 @@ We are ready to invoke the map. Combine `mutate()` with `invoke_map()` as follow
 
 ```{r}
 models_tbl_fit <- models_tbl %>%
-    mutate(fit = invoke_map(f, params))
+    mutate(fit = purrr::invoke_map(f, params))
 models_tbl_fit
 ```
 
@@ -281,15 +286,15 @@ models_tbl_fcast_tidy %>%
     unnest(sweep) %>%
     ggplot(aes(x = date, y = price, color = key, group = f)) +
     geom_ribbon(aes(ymin = lo.95, ymax = hi.95), 
-                fill = "#D5DBFF", color = NA, size = 0) +
+                fill = "#D5DBFF", color = NA, linewidth = 0) +
     geom_ribbon(aes(ymin = lo.80, ymax = hi.80, fill = key), 
-                fill = "#596DD5", color = NA, size = 0, alpha = 0.8) +
-    geom_line(size = 1) +
+                fill = "#596DD5", color = NA, linewidth = 0, alpha = 0.8) +
+    geom_line(linewidth = 1) +
     facet_wrap(~f, nrow = 3) +
     labs(title = "Gasoline Price Forecasts",
          subtitle = "Forecasting multiple models with sweep: ARIMA, BATS, ETS",
          x = "", y = "Price") +
-    scale_y_continuous(labels = scales::dollar) +
+    scale_y_continuous(labels = scales::label_dollar()) +
     scale_x_date(date_breaks = "5 years", date_labels = "%Y") +
     theme_tq() +
     scale_color_tq()


### PR DESCRIPTION
Also replace a usage of select_() by select()

Fix CRAN note of unused import! https://cran.r-project.org/web/checks/check_results_sweep.html

When you release to CRAN, tidyquant should go first to see if anything unexpected happens.